### PR TITLE
fix lintian warnings, typos

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,4 +8,16 @@ Homepage: http://clonekeenplus.sourceforge.net
 Package: commandergenius
 Architecture: any
 Depends: libsdl2-2.0-0, libogg0, libvorbis0a, libboost1.54-dev, libsdl2-image-2.0-0
-Description: Commander-Genius aka CloneKeenPlus is an engine which interprets Commander Keen 1-6 (Vorticons and Galaxy Series).\n .\n As fans and developers we try to implement new features, improve the gameplay and give the feeling, you are playing the original game.\n .\n Obviously you need the game data of the games to play it.\n Commander Keen 1 and 4 come included in this package.\n Episode 2, 3, 5 and 6 are registered versions which can be purchased by 3D Realms or Apogee, or bought by someone else.\n If you still have the old games of the registered version, then give it a try. You will be surprised, how well they will look!
+Description: engine used to play the "Commander Keen" game series
+ Commander-Genius aka CloneKeenPlus is an engine which interprets
+ Commander Keen 1-6 (Vorticons and Galaxy Series).
+ .
+ As fans and developers we try to implement new features, improve the
+ gameplay and give the feeling, you are playing the original game.
+ .
+ Obviously you need the game data of the games to play it.
+ Commander Keen 1 and 4 come included in this package.
+ Episode 2, 3, 5 and 6 are registered versions which can be
+ purchased by 3D Realms or Apogee, or bought by someone else.
+ If you still have the old games of the registered version,
+ then give it a try. You will be surprised, how well they will look!

--- a/debian/rules
+++ b/debian/rules
@@ -16,7 +16,7 @@ binary-indep:
 
 binary-arch:
 	cd $(BUILDDIR); cmake -P cmake_install.cmake
-	mkdir debian/tmp/DEBIAN
+	mkdir -p debian/tmp/DEBIAN
 	dpkg-gencontrol -pcommandergenius
 	dpkg --build debian/tmp ..
 

--- a/src/engine/CGameLauncher.cpp
+++ b/src/engine/CGameLauncher.cpp
@@ -217,7 +217,7 @@ bool CGameLauncher::loadResources()
         if(!found)
         {
             const std::string err = "The game from directory: \"" + gameDir + "\" cannot the launched." +
-                    "Maybe it's missing or not compatible. Please check if you can run that throught the game launcher.\n";
+                    "Maybe it's missing or not compatible. Please check if you can run that through the game launcher.\n";
 
             gLogging.textOut(err);
 

--- a/src/engine/core/CMap.cpp
+++ b/src/engine/core/CMap.cpp
@@ -636,7 +636,7 @@ void CMap::refreshVisibleArea()
 void CMap::redrawAt(const Uint32 mx, const Uint32 my)
 {
     SDL_Surface *ScrollSurface = gVideoDriver.getScrollSurface();
-	// Go throught the list and just draw all the tiles that need to be animated
+	// Go through the list and just draw all the tiles that need to be animated
 	const Uint32 num_h_tiles = ScrollSurface->h/16;
 	const Uint32 num_v_tiles = ScrollSurface->w/16;
 
@@ -889,7 +889,7 @@ void CMap::animateAllTiles()
     }
 
 
-    // Go throught the list and just draw all the tiles that need to be animated
+    // Go through the list and just draw all the tiles that need to be animated
     Uint32 num_h_tiles = ScrollSurface->h/16;
     Uint32 num_v_tiles = ScrollSurface->w/16;
 

--- a/src/fileio/CSaveGameController.cpp
+++ b/src/fileio/CSaveGameController.cpp
@@ -631,7 +631,7 @@ bool CSaveGameController::load()
 	StateFile.close();
 
 	// Done!
-	gLogging.textOut("File \""+ fullpath +"\" was sucessfully loaded. Size: "+itoa(m_datablock.size())+"\n");
+	gLogging.textOut("File \""+ fullpath +"\" was successfully loaded. Size: "+itoa(m_datablock.size())+"\n");
 	m_offset = 0;
 	m_statefilename.clear();
 	m_statename.clear();
@@ -707,7 +707,7 @@ bool CSaveGameController::save()
 	m_datablock.clear();
 
 	// Done!
-	gLogging.textOut("File \""+ fullpath +"\" was sucessfully saved. Size: "+itoa(size)+"\n");
+	gLogging.textOut("File \""+ fullpath +"\" was successfully saved. Size: "+itoa(size)+"\n");
 	m_statefilename.clear();
 	m_statename.clear();
 


### PR DESCRIPTION
This is just non-intrusive ground work to include CG in Debian?

This solves these lintian warnings:

```
I: commandergenius: spelling-error-in-binary usr/games/CGeniusExe throught through
I: commandergenius: spelling-error-in-binary usr/games/CGeniusExe sucessfully successfully
W: commandergenius: description-too-long
E: commandergenius: extended-description-is-empty
```

---

Now for the remaining ones:

`W: commandergenius: binary-without-manpage usr/games/CGeniusExe`

Would you accept to ship a manpage upstream if I provide one ?
What are the accepted command-line parameters ?  
I tried `-v / --version / -h / --help` with no luck.

---

```
E: commandergenius: unstripped-binary-or-object usr/games/CGeniusExe
E: commandergenius: missing-dependency-on-libc needed by usr/games/CGeniusExe
E: commandergenius: changelog-file-missing-in-native-package
E: commandergenius: no-copyright-file
W: commandergenius: hardening-no-relro usr/games/CGeniusExe
I: commandergenius: no-md5sums-control-file
I: commandergenius: hardening-no-fortify-functions usr/games/CGeniusExe
X: commandergenius: missing-dependency-on-libstdc++ needed by usr/games/CGeniusExe
```

Most of these warning would likely disappear if you switched to DebHelper 9:
(Launchpad can handle this)
https://wiki.debian.org/IntroDebianPackaging

I can provide a P.R. for that too, but I can't test it in launchpad myself.

----

```
I: commandergenius: arch-dep-package-has-big-usr-share 14353kB 80%
```

The original shareware data will likely not be shipped in the Debian
package, only the GPL-3 CG bits.  
But there is a dedicated tool to handle this problem: `game-data-packager` .

I filed and will most likely handle this game request:
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=786501

----

```
I: commandergenius: desktop-entry-lacks-keywords-entry usr/share/applications/cgenius.desktop
```

Worthless warning