### PR TITLE
Don't include dbfusion header when disabled

### DIFF
--- a/src/engine/CGameLauncher.cpp
+++ b/src/engine/CGameLauncher.cpp
@@ -35,7 +35,9 @@
 #include "keen/vorticon/VorticonEngine.h"
 #include "keen/galaxy/GalaxyEngine.h"
 #include "keen/dreams/dreamsengine.h"
+#ifdef DBFUSION
 #include "dbfusion/dbFusionNgine.h"
+#endif // DBFUSION
 
 bool disallowDBFusion = false;
 


### PR DESCRIPTION
This allows deleting the src/dbfusion folder completely when building without
dbfusion support, thus having a 6MB smaller tarball.