### PR TITLE
Fix build with SDL_ttf 2.24

### DIFF
--- a/GsKit/graphics/GsTrueTypeFont.h
+++ b/GsKit/graphics/GsTrueTypeFont.h
@@ -6,7 +6,7 @@
 #include <base/interface/Color.h>
 #include <graphics/GsSurface.h>
 
-typedef struct _TTF_Font TTF_Font;
+typedef struct TTF_Font TTF_Font;
 
 class GsTrueTypeFont
 {


### PR DESCRIPTION
SDL_ttf v. 2.24 has renamed the internal `_TTF_Font` struct to `TTF_Font` [^1] (the v3 branch also introduced this in v. 3.1.2 [^2]).

[^1]: https://github.com/libsdl-org/SDL_ttf/commit/7185085beb39b9e8b17d18685a2a58a14b7c53ef
[^2]: https://github.com/libsdl-org/SDL_ttf/commit/22347419ee08e49d77411c680f15e314ef870ab7

This breaks the build at least for current NixOS iterations; cf. this build output:
```
[ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsTilemap.cpp.o
[ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsDynColor.cpp.o
[ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/CColorMerge.cpp.o
[ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/CDimDark.cpp.o
In file included from /build/source/GsKit/graphics/GsTrueTypeFont.cpp:5:
/nix/store/8jafv6qwhwyrzpz8f323rqdjxw2qklyz-SDL2_ttf-2.24.0/include/SDL2/SDL_ttf.h:165:16: error: using typedef-name 'TTF_Font' after 'struct'
  165 | typedef struct TTF_Font TTF_Font;
      |                ^~~~~~~~
In file included from /build/source/GsKit/graphics/GsTrueTypeFont.cpp:2:
/build/source/GsKit/graphics/GsTrueTypeFont.h:9:26: note: 'TTF_Font' has a previous declaration here
    9 | typedef struct _TTF_Font TTF_Font;
      |                          ^~~~~~~~
/nix/store/8jafv6qwhwyrzpz8f323rqdjxw2qklyz-SDL2_ttf-2.24.0/include/SDL2/SDL_ttf.h:165:25: error: conflicting declaration 'typedef int TTF_Font'
  165 | typedef struct TTF_Font TTF_Font;
      |                         ^~~~~~~~
/build/source/GsKit/graphics/GsTrueTypeFont.h:9:26: note: previous declaration as 'typedef struct _TTF_Font TTF_Font'
    9 | typedef struct _TTF_Font TTF_Font;
      |                          ^~~~~~~~
make[2]: *** [GsKit/graphics/CMakeFiles/GsKit_graphics.dir/build.make:135: GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsTrueTypeFont.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[1]: *** [CMakeFiles/Makefile2:937: GsKit/graphics/CMakeFiles/GsKit_graphics.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
error: builder for '/nix/store/rgpapisirhjgpskp66as8wygnr401iyy-commandergenius-3.5.2.drv' failed with exit code 2;
       last 25 log lines:
       > [ 34%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsScrollsurface.cpp.o
       > [ 34%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsFont.cpp.o
       > [ 34%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsPalette.cpp.o
       > [ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsTilemap.cpp.o
       > [ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsDynColor.cpp.o
       > [ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/CColorMerge.cpp.o
       > [ 35%] Building CXX object GsKit/graphics/CMakeFiles/GsKit_graphics.dir/CDimDark.cpp.o
       > In file included from /build/source/GsKit/graphics/GsTrueTypeFont.cpp:5:
       > /nix/store/8jafv6qwhwyrzpz8f323rqdjxw2qklyz-SDL2_ttf-2.24.0/include/SDL2/SDL_ttf.h:165:16: error: using typedef-name 'TTF_Font' after 'struct'
       >   165 | typedef struct TTF_Font TTF_Font;
       >       |                ^~~~~~~~
       > In file included from /build/source/GsKit/graphics/GsTrueTypeFont.cpp:2:
       > /build/source/GsKit/graphics/GsTrueTypeFont.h:9:26: note: 'TTF_Font' has a previous declaration here
       >     9 | typedef struct _TTF_Font TTF_Font;
       >       |                          ^~~~~~~~
       > /nix/store/8jafv6qwhwyrzpz8f323rqdjxw2qklyz-SDL2_ttf-2.24.0/include/SDL2/SDL_ttf.h:165:25: error: conflicting declaration 'typedef int TTF_Font'
       >   165 | typedef struct TTF_Font TTF_Font;
       >       |                         ^~~~~~~~
       > /build/source/GsKit/graphics/GsTrueTypeFont.h:9:26: note: previous declaration as 'typedef struct _TTF_Font TTF_Font'
       >     9 | typedef struct _TTF_Font TTF_Font;
       >       |                          ^~~~~~~~
       > make[2]: *** [GsKit/graphics/CMakeFiles/GsKit_graphics.dir/build.make:135: GsKit/graphics/CMakeFiles/GsKit_graphics.dir/GsTrueTypeFont.cpp.o] Error 1
       > make[2]: *** Waiting for unfinished jobs....
       > make[1]: *** [CMakeFiles/Makefile2:937: GsKit/graphics/CMakeFiles/GsKit_graphics.dir/all] Error 2
       > make: *** [Makefile:156: all] Error 2
       For full logs, run:
         nix log /nix/store/rgpapisirhjgpskp66as8wygnr401iyy-commandergenius-3.5.2.drv
```