### PR TITLE
Save stack space while handling errors

### DIFF
--- a/GsKit/base/lua/ldebug.c
+++ b/GsKit/base/lua/ldebug.c
@@ -657,8 +657,11 @@ l_noret luaG_runerror (lua_State *L, const char *fmt, ...) {
   va_start(argp, fmt);
   msg = luaO_pushvfstring(L, fmt, argp);  /* format message */
   va_end(argp);
-  if (isLua(ci))  /* if Lua function, add source:line information */
+  if (isLua(ci)) {  /* if Lua function, add source:line information */
     luaG_addinfo(L, msg, ci_func(ci)->p->source, currentline(ci));
+    setobjs2s(L, L->top - 2, L->top - 1);  /* remove 'msg' from the stack */
+    L->top--;
+  }
   luaG_errormsg(L);
 }
 

--- a/GsKit/base/lua/lvm.c
+++ b/GsKit/base/lua/lvm.c
@@ -490,8 +490,10 @@ void luaV_concat (lua_State *L, int total) {
       /* collect total length and number of strings */
       for (n = 1; n < total && tostring(L, top - n - 1); n++) {
         size_t l = vslen(top - n - 1);
-        if (l >= (MAX_SIZE/sizeof(char)) - tl)
+        if (l >= (MAX_SIZE/sizeof(char)) - tl) {
+          L->top = top - total;  /* pop strings to avoid wasting stack */
           luaG_runerror(L, "string length overflow");
+        }
         tl += l;
       }
       if (tl <= LUAI_MAXSHORTLEN) {  /* is result a short string? */
@@ -506,7 +508,7 @@ void luaV_concat (lua_State *L, int total) {
       setsvalue2s(L, top - n, ts);  /* create result */
     }
     total -= n-1;  /* got 'n' strings to create 1 new */
-    L->top -= n-1;  /* popped 'n' strings and pushed one */
+    L->top = top - (n - 1);  /* popped 'n' strings and pushed one */
   } while (total > 1);  /* repeat until only 1 result left */
 }
 


### PR DESCRIPTION
This PR fixes a potential security vulnerability in GsKit/base/lua/ldebug.c and GsKit/base/lua/lvm.c that were cloned from https://github.com/lua/lua but did not receive the security patch.

### Details:
Affected: GsKit/base/lua/ldebug.c and GsKit/base/lua/lvm.c
Original Fix: https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf

### What this PR does:
This PR applies the same security patch that was applied to the original repository to eliminate the potential vulnerability in the cloned code.

### References:
- https://github.com/lua/lua/commit/42d40581dd919fb134c07027ca1ce0844c670daf
- https://nvd.nist.gov/vuln/detail/cve-2022-33099

Please review and merge this PR to ensure your repository is protected against this potential vulnerability.
